### PR TITLE
Clarify file redirection semantics

### DIFF
--- a/src/fd_redirection.mli
+++ b/src/fd_redirection.mli
@@ -1,10 +1,11 @@
 open! Core
 
-(** This variant determines the where the file descriptor is redirect towards.
+(** This variant specifies how to redirect the file descriptor.
 
-    In the [`Dev_null] case it is redirected to /dev/null, ie is ignored.
+    In the [`Dev_null] case it is redirected to /dev/null, ie the output is ignored.
     
-    In both [`File_append location] and [`File_truncate location] it is redirected to [location], where [location] is the absolute path to the file. 
+    In both [`File_append location] and [`File_truncate location] it is redirected to [location], where [location] is the absolute path to the file.
+    Where [`File_append] will append to the file, while [`File_truncate] will fully overwrite it.
 *)
 type t =
   [ `Dev_null

--- a/src/fd_redirection.mli
+++ b/src/fd_redirection.mli
@@ -1,5 +1,11 @@
 open! Core
 
+(** This variant determines the where the file descriptor is redirect towards.
+
+    In the [`Dev_null] case it is redirected to /dev/null, ie is ignored.
+    
+    In both [`File_append location] and [`File_truncate location] it is redirected to [location], where [location] is the absolute path to the file. 
+*)
 type t =
   [ `Dev_null
   | `File_append of string


### PR DESCRIPTION
I've just spent a bit of time trying to work out why I'm getting a `permission denied` error while trying to redirect the output of a worker. This was because I was passing in a relative path rather than an absolute path.

It is currently undocumented that `File_truncate` and `File_append` need to take absolute paths and cannot take a relative path.

This PR adds that documentation.